### PR TITLE
Create consolidated npm script for setting up the app

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,11 @@ This app can optionally be run entirely in Docker. This can be used to avoid set
   - Postgres Server URL: postgresql://postgres:postgres@localhost:5432/pet_names
 
 ### App Scripts
+- Full App Setup: `npm run app:install`
+- Full App Start: `npm run app:start`
 - Start Server: `npm run server:start`
 - Server Reset Database (with seed): `npm run server:db:setup`
 - Server Reset Database (without seed): `npm run server:db:reset`
 - Frontend Start: `npm run client:start`
-- Full App Start: `npm run app:start`
 - Cypress Run (without app): `npm run cypress`
 - Cypress Run (with app): `npm run cypress:app`

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "server:db:setup": "cd server && npm i && npm run db:setup",
     "server:db:reset": "cd server && npm i && npm run db:reset",
     "client:start": "cd client && npm i && npm start",
+    "app:install": "cd client && npm i && cd ../server && npm i && npm run db:setup",
     "app:start": "concurrently \"npm run server:start\" \"npm run client:start\"",
     "cypress": "cypress open",
     "cypress:app": "concurrently \"npm run server:start\" \"npm run client:start\" \"npm run cypress\""

--- a/server/knex_create.js
+++ b/server/knex_create.js
@@ -4,4 +4,7 @@ const knex = require('knex')({
   connection: process.env.DB_SETUP_URL,
 });
 
-knex.raw('CREATE DATABASE pet_names;').then(() => process.exit(0));
+knex
+  .raw('CREATE DATABASE pet_names;')
+  .catch((error) => console.log('Unable to create database pet_names. Proceeding assuming it already exists.'))
+  .finally(() => process.exit(0));

--- a/server/seeds/100-pet-names.js
+++ b/server/seeds/100-pet-names.js
@@ -2,9 +2,12 @@
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
  */
+
 exports.seed = async function (knex) {
-  // Deletes ALL existing entries
-  await knex('pet_names').del();
+  const result = await knex('pet_names').count('id');
+  const recordCount = parseInt(result[0]?.count)
+  if (recordCount > 0) { return; }
+
   await knex('pet_names').insert([
     { id: 7, name: 'Max', is_male: true },
     { id: 8, name: 'Charlie', is_male: true },


### PR DESCRIPTION
Closes #45 

Add an npm script to the root level package.json to setup client, server, and database. This allows the app to be setup and run with these two scripts:

- `npm run app:install`
- `npm run app:start`